### PR TITLE
Add Cypress tests and documentation

### DIFF
--- a/backend/internal/token.js
+++ b/backend/internal/token.js
@@ -102,7 +102,7 @@ module.exports = {
 			.first()
 			.then((user) => {
 				if (!user) {
-					throw new error.AuthError('No relevant user found');
+					throw new error.AuthError(`A user with the email ${data.identity} does not exist. Please contact your administrator.`);
 				}
 
 				// Create a moment of the expiry expression

--- a/docs/src/setup/index.md
+++ b/docs/src/setup/index.md
@@ -146,4 +146,38 @@ Immediately after logging in with this default user you will be asked to modify 
       INITIAL_ADMIN_PASSWORD: mypassword1
 ```
 
+## OpenID Connect - Single Sign-On (SSO)
+
+Nginx Proxy Manager supports single sign-on (SSO) with OpenID Connect. This feature allows you to use an external OpenID Connect provider log in.
+*Note: This feature requires a user to have an existing account to have been created via the "Users" page in the admin interface.*
+
+### Provider Configuration
+However, before you configure this feature, you need to have an OpenID Connect provider.
+If you don't have one, you can use Authentik, which is an open-source OpenID Connect provider. Auth0 is another popular OpenID Connect provider that offers a free tier.
+
+Each provider is a little different, so you will need to refer to the provider's documentation to get the necessary information to configure a new application.
+You will need the `Client ID`, `Client Secret`, and `Issuer URL` from the provider. When you create the application in the provider, you will also need to include the `Redirect URL` in the list of allowed redirect URLs for the application.
+Nginx Proxy Manager uses the `/api/oidc/callback` endpoint for the redirect URL.
+The scopes requested by Nginx Proxy Manager are `openid`, `email`, and `profile` - make sure your auth provider supports these scopes.
+
+We have confirmed that the following providers work with Nginx Proxy Manager. If you have success with another provider, make a pull request to add it to the list!
+- Authentik
+- Authelia
+- Auth0
+
+### Nginx Proxy Manager Configuration
+To enable SSO, log into the management interface as an Administrator and navigate to the "Settings" page.
+The setting to configure OpenID Connect is named "OpenID Connect Configuration".
+Click the 3 dots on the far right side of the table and then click "Edit".
+In the modal that appears, you will see a form with the following fields:
+
+| Field         | Description                                               | Example Value                               | Notes                                                               |
+|---------------|-----------------------------------------------------------|---------------------------------------------|---------------------------------------------------------------------|
+| Name          | The name of the OpenID Connect provider                   | Authentik                                   | This will be shown on the login page (eg: "Sign in with Authentik") |
+| Client ID     | The client ID provided by the OpenID Connect provider     | `xyz...456`                                 |                                                                     |
+| Client Secret | The client secret provided by the OpenID Connect provider | `abc...123`                                 |
+| Issuer URL    | The issuer URL provided by the OpenID Connect provider    | `https://authentik.example.com`             | This is the URL that the provider uses to identify itself           |
+| Redirect URL  | The redirect URL to use for the OpenID Connect provider   | `https://npm.example.com/api/oidc/callback` |                                                                     |
+
+After filling in the fields, click "Save" to save the settings. You can now use the "Sign in with Authentik" button on the login page to sign in with your OpenID Connect provider.
 

--- a/docs/src/setup/index.md
+++ b/docs/src/setup/index.md
@@ -149,7 +149,12 @@ Immediately after logging in with this default user you will be asked to modify 
 ## OpenID Connect - Single Sign-On (SSO)
 
 Nginx Proxy Manager supports single sign-on (SSO) with OpenID Connect. This feature allows you to use an external OpenID Connect provider log in.
-*Note: This feature requires a user to have an existing account to have been created via the "Users" page in the admin interface.*
+
+::: warning
+
+Please note, that this feature requires a user to have an existing account to have been created via the "Users" page in the admin interface.
+
+:::
 
 ### Provider Configuration
 However, before you configure this feature, you need to have an OpenID Connect provider.

--- a/frontend/js/app/dashboard/main.ejs
+++ b/frontend/js/app/dashboard/main.ejs
@@ -1,5 +1,5 @@
 <div class="page-header">
-    <h1 class="page-title"><%- i18n('dashboard', 'title', {name: getUserName()}) %></h1>
+    <h1 class="page-title" data-cy="page-title"><%- i18n('dashboard', 'title', {name: getUserName()}) %></h1>
 </div>
 
 <% if (columns) { %>

--- a/frontend/js/i18n/messages.json
+++ b/frontend/js/i18n/messages.json
@@ -296,7 +296,7 @@
       "oidc-config-description": "Sign in to Nginx Proxy Manager with an external Identity Provider",
       "oidc-not-configured": "Not configured",
       "oidc-config-hint-1": "Provide configuration for an IdP that supports Open ID Connect Discovery.",
-      "oidc-config-hint-2": "The 'RedirectURL' must be set to '[base URL]/api/oidc/callback', the IdP must send the 'email' claim and a user with matching email address must exist in Nginx Proxy Manager."
+      "oidc-config-hint-2": "The 'Redirect URL' must be set to '[base URL]/api/oidc/callback', the IdP must send the 'email' claim and a user with matching email address must exist in Nginx Proxy Manager."
     }
   }
 }

--- a/frontend/js/login/ui/login.ejs
+++ b/frontend/js/login/ui/login.ejs
@@ -17,19 +17,19 @@
                                 <div class="card-title"><%- i18n('login', 'title') %></div>
                                 <div class="form-group">
                                     <label class="form-label"><%- i18n('str', 'email-address') %></label>
-                                    <input name="identity" type="email" class="form-control" placeholder="<%- i18n('str', 'email-address') %>" required autofocus>
+                                    <input name="identity" type="email" class="form-control" placeholder="<%- i18n('str', 'email-address') %>" data-cy="identity" required autofocus>
                                 </div>
                                 <div class="form-group">
                                     <label class="form-label"><%- i18n('str', 'password') %></label>
-                                    <input name="secret" type="password" class="form-control" placeholder="<%- i18n('str', 'password') %>" required>
-                                    <div class="invalid-feedback secret-error"></div>
+                                    <input name="secret" type="password" class="form-control" placeholder="<%- i18n('str', 'password') %>" data-cy="password" required>
+                                    <div class="invalid-feedback secret-error" data-cy="password-error"></div>
                                 </div>
                                 <div class="form-footer">
-                                    <button type="submit" class="btn btn-teal btn-block"><%- i18n('str', 'sign-in') %></button>
+                                    <button type="submit" class="btn btn-teal btn-block" data-cy="sign-in"><%- i18n('str', 'sign-in') %></button>
                                 </div>
                                 <div class="form-footer login-oidc">
                                     <div class="separator"><slot>OR</slot></div>
-                                    <button type="button" id="login-oidc" class="btn btn-teal btn-block">
+                                    <button type="button" id="login-oidc" class="btn btn-teal btn-block" data-cy="oidc-login">
                                         <%- i18n('str', 'sign-in-with') %> <span class="oidc-provider"></span>
                                     </button>
                                     <div class="invalid-feedback oidc-error"></div>

--- a/test/cypress/e2e/api/Settings.cy.js
+++ b/test/cypress/e2e/api/Settings.cy.js
@@ -19,6 +19,51 @@ describe('Settings endpoints', () => {
 		});
 	});
 
+	it('Get oidc-config setting', function() {
+		cy.task('backendApiGet', {
+			token: token,
+			path:  '/api/settings/oidc-config',
+		}).then((data) => {
+			cy.validateSwaggerSchema('get', 200, '/settings/{settingID}', data);
+			expect(data).to.have.property('id');
+			expect(data.id).to.be.equal('oidc-config');
+		});
+	});
+
+	it('OIDC settings can be updated', function() {
+		cy.task('backendApiPut', {
+			token: token,
+			path:  '/api/settings/oidc-config',
+			data: {
+				meta: {
+					name: 'Some OIDC Provider',
+					clientID: 'clientID',
+					clientSecret: 'clientSecret',
+					issuerURL: 'https://oidc.example.com',
+					redirectURL: 'https://redirect.example.com/api/oidc/callback',
+					enabled: true,
+				}
+			},
+		}).then((data) => {
+			cy.validateSwaggerSchema('put', 200, '/settings/{settingID}', data);
+			expect(data).to.have.property('id');
+			expect(data.id).to.be.equal('oidc-config');
+			expect(data).to.have.property('meta');
+			expect(data.meta).to.have.property('name');
+			expect(data.meta.name).to.be.equal('Some OIDC Provider');
+			expect(data.meta).to.have.property('clientID');
+			expect(data.meta.clientID).to.be.equal('clientID');
+			expect(data.meta).to.have.property('clientSecret');
+			expect(data.meta.clientSecret).to.be.equal('clientSecret');
+			expect(data.meta).to.have.property('issuerURL');
+			expect(data.meta.issuerURL).to.be.equal('https://oidc.example.com');
+			expect(data.meta).to.have.property('redirectURL');
+			expect(data.meta.redirectURL).to.be.equal('https://redirect.example.com/api/oidc/callback');
+			expect(data.meta).to.have.property('enabled');
+			expect(data.meta.enabled).to.be.true;
+		});
+	});
+
 	it('Get default-site setting', function() {
 		cy.task('backendApiGet', {
 			token: token,

--- a/test/cypress/e2e/ui/Login.cy.js
+++ b/test/cypress/e2e/ui/Login.cy.js
@@ -1,0 +1,185 @@
+/// <reference types="cypress" />
+
+import {TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD} from "../../support/constants";
+
+describe('Login', () => {
+    beforeEach(() => {
+        // Clear all cookies and local storage so we start fresh
+        cy.clearCookies();
+        cy.clearLocalStorage();
+    });
+
+    describe('when OIDC is not enabled', () => {
+        beforeEach(() => {
+            cy.configureOidc(false);
+            cy.visit('/');
+        })
+
+        it('should show the login form', () => {
+            cy.get('input[data-cy="identity"]').should('exist');
+            cy.get('input[data-cy="password"]').should('exist');
+            cy.get('button[data-cy="sign-in"]').should('exist');
+        });
+
+        it('should NOT show the button to sign in with an identity provider', () => {
+            cy.get('button[data-cy="oidc-login"]').should('not.exist');
+        });
+
+        describe('logging in with a username and password', () => {
+            // These tests are duplicated below. The difference is that OIDC is disabled here.
+            beforeEach(() => {
+                // Delete and recreate the test user
+                cy.deleteTestUser();
+                cy.createTestUser();
+            });
+
+            it('should log the user in when the credentials are correct', () => {
+                // Fill in the form with the test user's email and the correct password
+                cy.get('input[data-cy="identity"]').type(TEST_USER_EMAIL);
+                cy.get('input[data-cy="password"]').type(TEST_USER_PASSWORD);
+
+                // Intercept the POST request to /api/tokens, so we can wait for it to complete before proceeding
+                cy.intercept('POST', '/api/tokens').as('login');
+
+                // Click the sign-in button
+                cy.get('button[data-cy="sign-in"]').click();
+                cy.wait('@login');
+
+                // Expect a 200 from the backend
+                cy.get('@login').its('response.statusCode').should('eq', 200);
+
+                // Expect the user to be redirected to the dashboard with a welcome message
+                cy.get('h1[data-cy="page-title"]').should('contain.text', `Hi ${TEST_USER_NICKNAME}`);
+            });
+
+            it('should show an error message if the password is incorrect', () => {
+                // Fill in the form with the test user's email and an incorrect password
+                cy.get('input[data-cy="identity"]').type(TEST_USER_EMAIL);
+                cy.get('input[data-cy="password"]').type(`${TEST_USER_PASSWORD}_obviously_not_correct`);
+
+                // Intercept the POST request to /api/tokens, so we can wait for it to complete before checking the error message
+                cy.intercept('POST', '/api/tokens').as('login');
+
+                // Click the sign-in button
+                cy.get('button[data-cy="sign-in"]').click();
+                cy.wait('@login');
+
+                // Expect a 401 from the backend
+                cy.get('@login').its('response.statusCode').should('eq', 401);
+                // Expect an error message on the UI
+                cy.get('div[data-cy="password-error"]').should('contain.text', 'Invalid password');
+            });
+
+            it('should show an error message if the email is incorrect', () => {
+                // Fill in the form with the test user's email and an incorrect password
+                cy.get('input[data-cy="identity"]').type(`definitely_not_${TEST_USER_EMAIL}`);
+                cy.get('input[data-cy="password"]').type(TEST_USER_PASSWORD);
+
+                // Intercept the POST request to /api/tokens, so we can wait for it to complete before checking the error message
+                cy.intercept('POST', '/api/tokens').as('login');
+
+                // Click the sign-in button
+                cy.get('button[data-cy="sign-in"]').click();
+                cy.wait('@login');
+
+                // Expect a 401 from the backend
+                cy.get('@login').its('response.statusCode').should('eq', 401);
+                // Expect an error message on the UI
+                cy.get('div[data-cy="password-error"]').should('contain.text', 'No relevant user found');
+            });
+        });
+    });
+
+    describe('when OIDC is enabled', () => {
+        beforeEach(() => {
+            cy.configureOidc(true);
+            cy.visit('/');
+        });
+
+        it('should show the login form', () => {
+            cy.get('input[data-cy="identity"]').should('exist');
+            cy.get('input[data-cy="password"]').should('exist');
+            cy.get('button[data-cy="sign-in"]').should('exist');
+        });
+
+        it('should show the button to sign in with the configured identity provider', () => {
+            cy.get('button[data-cy="oidc-login"]').should('exist');
+            cy.get('button[data-cy="oidc-login"]').should('contain.text', 'Sign in with ACME OIDC Provider');
+        });
+
+        describe('logging in with a username and password', () => {
+            // These tests are the same as the ones above, but we need to repeat them here because the OIDC configuration
+            beforeEach(() => {
+                // Delete and recreate the test user
+                cy.deleteTestUser();
+                cy.createTestUser();
+            });
+
+            it('should log the user in when the credentials are correct', () => {
+                // Fill in the form with the test user's email and the correct password
+                cy.get('input[data-cy="identity"]').type(TEST_USER_EMAIL);
+                cy.get('input[data-cy="password"]').type(TEST_USER_PASSWORD);
+
+                // Intercept the POST request to /api/tokens, so we can wait for it to complete before proceeding
+                cy.intercept('POST', '/api/tokens').as('login');
+
+                // Click the sign-in button
+                cy.get('button[data-cy="sign-in"]').click();
+                cy.wait('@login');
+
+                // Expect a 200 from the backend
+                cy.get('@login').its('response.statusCode').should('eq', 200);
+
+                // Expect the user to be redirected to the dashboard with a welcome message
+                cy.get('h1[data-cy="page-title"]').should('contain.text', `Hi ${TEST_USER_NICKNAME}`);
+
+            });
+
+            it('should show an error message if the password is incorrect', () => {
+                // Fill in the form with the test user's email and an incorrect password
+                cy.get('input[data-cy="identity"]').type(TEST_USER_EMAIL);
+                cy.get('input[data-cy="password"]').type(`${TEST_USER_PASSWORD}_obviously_not_correct`);
+
+                // Intercept the POST request to /api/tokens, so we can wait for it to complete before checking the error message
+                cy.intercept('POST', '/api/tokens').as('login');
+
+                // Click the sign-in button
+                cy.get('button[data-cy="sign-in"]').click();
+                cy.wait('@login');
+
+                // Expect a 401 from the backend
+                cy.get('@login').its('response.statusCode').should('eq', 401);
+                // Expect an error message on the UI
+                cy.get('div[data-cy="password-error"]').should('contain.text', 'Invalid password');
+            });
+
+            it('should show an error message if the email is incorrect', () => {
+                // Fill in the form with the test user's email and an incorrect password
+                cy.get('input[data-cy="identity"]').type(`definitely_not_${TEST_USER_EMAIL}`);
+                cy.get('input[data-cy="password"]').type(TEST_USER_PASSWORD);
+
+                // Intercept the POST request to /api/tokens, so we can wait for it to complete before checking the error message
+                cy.intercept('POST', '/api/tokens').as('login');
+
+                // Click the sign-in button
+                cy.get('button[data-cy="sign-in"]').click();
+                cy.wait('@login');
+
+                // Expect a 401 from the backend
+                cy.get('@login').its('response.statusCode').should('eq', 401);
+                // Expect an error message on the UI
+                cy.get('div[data-cy="password-error"]').should('contain.text', 'No relevant user found');
+            });
+        });
+
+        describe('logging in with OIDC', () => {
+           beforeEach(() => {
+                // Delete and recreate the test user
+                cy.deleteTestUser();
+                cy.createTestUser();
+           });
+
+           // TODO: Create a dummy OIDC provider that we can use for testing so we can test this fully.
+        });
+    });
+});

--- a/test/cypress/support/constants.js
+++ b/test/cypress/support/constants.js
@@ -1,0 +1,16 @@
+// Description: Constants used in the tests.
+
+/**
+ *  The default admin user is used to get tokens from the backend API to make requests.
+ *  It is also used to create the test user.
+ */
+export const DEFAULT_ADMIN_EMAIL = Cypress.env('DEFAULT_ADMIN_EMAIL') || 'admin@example.com';
+export const DEFAULT_ADMIN_PASSWORD =  Cypress.env('DEFAULT_ADMIN_PASSWORD') || 'changeme';
+
+/**
+ * The test user is created and deleted by the tests using `cy.createTestUser()` and `cy.deleteTestUser()`.
+ */
+export const TEST_USER_NAME = 'Robert Ross';
+export const TEST_USER_NICKNAME = 'Bob';
+export const TEST_USER_EMAIL = 'bob@ross.com';
+export const TEST_USER_PASSWORD = 'changeme';


### PR DESCRIPTION
This PR addresses some things requested by the maintainer of NGINX Proxy Manager

- Cypress automated tests
- Documentation for setting up SSO with OIDC
- A more user-friendly error message for when a user does not exist in NPM and they are attempting to sign in via an IdP
- Fixing a typo in the "hint" description so that the name of "Redirect URL" matches the field label in the modal.